### PR TITLE
added check for fl_decode_uri in FL/filename.H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,23 +22,23 @@ AC_PROG_CXX
 
 # Checks for libraries.
 
-AC_CHECK_LIB([fltk],[fl_system],,
-  AC_MSG_ERROR([libfltk missing]))
+AC_CHECK_LIB([fltk],[fl_system],[],
+  [AC_MSG_ERROR([libfltk missing])])
 
-AC_CHECK_LIB([fltk_images],[fl_numericsort],,
-  AC_MSG_ERROR([libfltk_images missing]))
+AC_CHECK_LIB([fltk_images],[fl_numericsort],[],
+  [AC_MSG_ERROR([libfltk_images missing])])
 
-AC_CHECK_LIB([jpeg],[jpeg_start_output],,
-  AC_MSG_ERROR([libjpeg missing]))
+AC_CHECK_LIB([jpeg],[jpeg_start_output],[],
+  [AC_MSG_ERROR([libjpeg missing])])
 
-AC_CHECK_LIB([png],[png_malloc],,
-  AC_MSG_ERROR([libpng missing]))
+AC_CHECK_LIB([png],[png_malloc],[],
+  [AC_MSG_ERROR([libpng missing])])
 
-AC_CHECK_LIB([z],[gzopen],,
-  AC_MSG_ERROR([libz missing]))
+AC_CHECK_LIB([z],[gzopen],[],
+  [AC_MSG_ERROR([libz missing])])
 
-AC_CHECK_LIB([X11],[XInitThreads],,
-  AC_MSG_ERROR([libX11 missing]))
+AC_CHECK_LIB([X11],[XInitThreads],[],
+  [AC_MSG_ERROR([libX11 missing])])
 
 
 # Checks for header files.
@@ -61,7 +61,19 @@ AC_TYPE_INT64_T
 
 
 # Checks for library functions.
+
 AC_CHECK_FUNCS([pow sqrt strcasecmp])
+
+
+dnl Checks for symbol declarations
+
+AC_CHECK_DECLS(
+[fl_decode_uri],
+[],
+[AC_MSG_ERROR([fl_decode_uri decl missing])],
+[[#include "FL/filename.H"]],
+)
+
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
this forces configure-time failure when fl_decode_uri is missing from FL/filename.H , i.e., before fltk v1.3.1
