### PR TITLE
adding rgba conversion convenience functionality

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,7 +133,10 @@ dist_pkgdata_DATA =     \
   data/zoom_out.png
 
 
-check_PROGRAMS = test_fltk_version
+check_PROGRAMS =    \
+  test_fltk_version \
+  test_endian
 test_fltk_version_SOURCES = test/fltk_version.cc
+test_endian_SOURCES = test/endian.cc
 
 TESTS = $(check_PROGRAMS)

--- a/configure.ac
+++ b/configure.ac
@@ -46,10 +46,9 @@ AC_CHECK_LIB([X11],[XInitThreads],[],
 
 dnl Checks for header files.
 
-dnl AC_CHECK_HEADERS([stdint.h stdlib.h])
-
-AC_CHECK_HEADER([stdint.h],[],[AC_MSG_ERROR([stdint.h missing])])
 AC_CHECK_HEADER([cstdlib],[],[AC_MSG_ERROR([cstdlib missing])])
+AC_CHECK_HEADER([endian.h],[],[AC_MSG_ERROR([endian.h missing])])
+AC_CHECK_HEADER([stdint.h],[],[AC_MSG_ERROR([stdint.h missing])])
 
 
 # Checks for typedefs, structures, and compiler characteristics.

--- a/inline.h
+++ b/inline.h
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 #include <stdint.h>
 
+#include "endian.h"
+
 // fast random number seed
 extern int seed;
 
@@ -31,6 +33,38 @@ inline int rnd32(void)
 {
   seed = (seed << 17) ^ (seed >> 13) ^ (seed << 5);
   return seed;
+}
+
+struct rgba_t
+{
+#if 0
+    /*  */
+#elif ( BYTE_ORDER == LITTLE_ENDIAN )
+    uint8_t r ;
+    uint8_t g ;
+    uint8_t b ;
+    uint8_t a ;
+#elif ( BYTE_ORDER == BIG_ENDIAN )
+    uint8_t a ;
+    uint8_t b ;
+    uint8_t g ;
+    uint8_t r ;
+#else
+#  error "unsupported endianness"
+#endif
+};
+
+union un_rgba_t
+{
+    uint32_t uint32_ ;
+    rgba_t rgba_ ;
+};
+
+inline rgba_t get_rgba( uint32_t const&n )
+{
+    un_rgba_t u ;
+    u.uint32_ = n ;
+    return u.rgba_ ;
 }
 
 inline int makecol(const int &r, const int &g, const int &b)

--- a/test/endian.cc
+++ b/test/endian.cc
@@ -1,0 +1,26 @@
+/* rendera/test/endian.cc */
+
+#include <iostream>
+#include <cassert>
+
+#include "rendera.h"
+#include "inline.h"
+
+int
+main( int, char** )
+{
+    assert( 4 == sizeof( rgba_t ) );
+    assert( 4 == sizeof( un_rgba_t ) );
+    assert( 1 == sizeof( rgba_t::r ) );
+    assert( 1 == sizeof( rgba_t::g ) );
+    assert( 1 == sizeof( rgba_t::b ) );
+    assert( 1 == sizeof( rgba_t::a ) );
+
+    rgba_t rgba = get_rgba( 0x03020100 );
+    assert( 0 == rgba.r );
+    assert( 1 == rgba.g );
+    assert( 2 == rgba.b );
+    assert( 3 == rgba.a );
+
+    return 0 ;
+}


### PR DESCRIPTION
rgba conversion is tough, this request makes it a little easier with:
- autoconf existence check for endian.h
- inline.h now:
  - is unix- (not DOS-) encoded
  - includes endian.h
  - defines new struct rgba_t
  - defines new union un_rgba_t
  - defines new function get_rgba that converts 32-bit integer to rgba_t
- Makefile.am has additional test_endian, unit test for everything above
- test/endian.cc, source for the unit test
