### PR TITLE
fixes installation location for pkgdata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,10 +118,10 @@ paths.h : Makefile
 	echo '#endif//ndef PATHS_H' >>$@
 
 
-dist_pkgdata_DATA_COMMON =                 \
+nobase_dist_pkgdata_DATA =          \
   data/common/icon48x48.png 
 
-dist_pkgdata_DATA_THEME_DARK =      \
+nobase_dist_pkgdata_DATA +=         \
   data/theme/dark/clone.png         \
   data/theme/dark/constrain.png     \
   data/theme/dark/grid.png          \
@@ -141,7 +141,7 @@ dist_pkgdata_DATA_THEME_DARK =      \
   data/theme/dark/zoom_one.png      \
   data/theme/dark/zoom_out.png
 
-dist_pkgdata_DATA_THEME_LIGHT =     \
+nobase_dist_pkgdata_DATA +=         \
   data/theme/light/clone.png        \
   data/theme/light/constrain.png    \
   data/theme/light/grid.png         \


### PR DESCRIPTION
This fixes the installation behavior as well as the paths to things that are installed to the `dist_pkgdata` directory.

Normal `automake` installation behavior depends on the `_DATA` suffix for `dist_pkgdata` primaries; i.e., things that are referenced by variables with a different suffix aren't installed (by default).

Also, I added the `nobase_` prefix to those variable names to prevent automake from collapsing the path for each of the `dist_pkgdata_DATA` files. This is necessary to prevent files with identical `basename` from colliding during execution of the `make install` target.
