### PR TITLE
fixes rendera_CXXFLAGS, adds AM_CXXFLAGS, source code tweaks to fix Werrors

### DIFF
--- a/Blend.H
+++ b/Blend.H
@@ -37,7 +37,7 @@ namespace Blend
     ALPHA_ADD,
     ALPHA_SUB,
     SMOOTH,
-    SMOOTH_COLOR,
+    SMOOTH_COLOR
   };
  
   void set(const int &);

--- a/File.cxx
+++ b/File.cxx
@@ -638,21 +638,21 @@ Bitmap *File::loadPng(const char *fn, int overscroll)
     std::vector<png_byte> data(rowbytes * h);
     std::vector<png_bytep> row_pointers(h);
 
-    for(int y = 0; y < h; y++)
+    for(size_t y = 0; y < h; y++)
       row_pointers[y] = &data[y * rowbytes];
 
     // read image all at once
     png_read_image(png_ptr, &row_pointers[0]);
 
     // convert image
-    for(int y = 0; y < h; y++)
+    for(size_t y = 0; y < h; y++)
     {
       int *p = temp->row[y + overscroll] + overscroll;
       int xx = 0;
 
       png_bytep row = row_pointers[y];
 
-      for(int x = 0; x < w; x++)
+      for(size_t x = 0; x < w; x++)
       {
         if(channels == 3)
         {
@@ -677,7 +677,7 @@ Bitmap *File::loadPng(const char *fn, int overscroll)
     // non-interlace images can be read line-by-line
     std::vector<png_byte> linebuf(rowbytes);
 
-    for(int y = 0; y < h; y++)
+    for(size_t y = 0; y < h; y++)
     {
       // read line
       png_read_row(png_ptr, &linebuf[0], 0);
@@ -686,7 +686,7 @@ Bitmap *File::loadPng(const char *fn, int overscroll)
       int xx = 0;
 
       // convert line
-      for(int x = 0; x < w; x++)
+      for(size_t x = 0; x < w; x++)
       {
         if(channels == 3)
         {
@@ -782,7 +782,7 @@ int File::saveBmp(const char *fn)
   int overscroll = Project::overscroll;
   int w = bmp->cw;
   int h = bmp->ch;
-  int pad = w % 4;
+  size_t pad = w % 4;
 
   // BMP_FILE_HEADER
   writeUint8('B', outp);
@@ -822,7 +822,7 @@ int File::saveBmp(const char *fn)
       xx += 3;
     }
 
-    for(int x = 0; x < pad; x++)
+    for(size_t x = 0; x < pad; x++)
       linebuf[xx++] = 0;
 
     p += overscroll * 2;
@@ -878,7 +878,7 @@ int File::saveTarga(const char *fn)
 
     p += overscroll * 2;
 
-    if(fwrite(&linebuf[0], 1, w * 4, outp) != w * 4)
+    if( size_t( w * 4 ) != fwrite(&linebuf[0], 1, w * 4, outp) )
       return -1;
   }
 

--- a/Gui.cxx
+++ b/Gui.cxx
@@ -440,7 +440,7 @@ void Gui::init()
 
   char s[8];
 
-  for(int i = 0; i < sizeof(font_sizes) / sizeof(font_sizes[0]); i++)
+  for(size_t i = 0, n = sizeof(font_sizes)/sizeof(font_sizes[0]); i < n; i++)
   {
     snprintf(s, sizeof(s), "%d", font_sizes[i]);
     font_size->add(s);

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,7 +84,7 @@ rendera_SOURCES =     \
 
 
 rendera_LDFLAGS = $(shell fltk-config --ldflags)
-rendera_CXXFLAGS = $(shell fltk-config --cxxflags)
+rendera_CXXFLAGS = $(shell fltk-config --cxxflags) $(AM_CXXFLAGS)
 
 
 nodist_rendera_SOURCES = paths.h

--- a/Paint.H
+++ b/Paint.H
@@ -23,7 +23,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 class View;
 
-#include "Rendera.H"
 #include "Tool.H"
 
 class Paint : public Tool

--- a/Paint.cxx
+++ b/Paint.cxx
@@ -35,9 +35,6 @@ namespace
 {
   int state = 0;
   bool active = 0;
-
-  int render_pos = 0, render_end = 0, render_count = 0;
-  float soft_trans = 0, soft_step = 0;
 }
 
 Paint::Paint()

--- a/Palette.cxx
+++ b/Palette.cxx
@@ -40,7 +40,6 @@ Palette::~Palette()
 
 void Palette::draw(Widget *widget)
 {
-  int x, y;
   int w = widget->w();
 
   int step = 3;

--- a/Project.H
+++ b/Project.H
@@ -35,7 +35,7 @@ namespace Project
   enum
   {
     THEME_LIGHT,
-    THEME_DARK,
+    THEME_DARK
   };
 
   extern Bitmap *bmp;

--- a/Text.cxx
+++ b/Text.cxx
@@ -89,11 +89,11 @@ void Text::push(View *view)
   view->drawMain(true);
 }
 
-void Text::drag(View *view)
+void Text::drag(View*)
 {
 }
 
-void Text::release(View *)
+void Text::release(View*)
 {
 }
 
@@ -117,9 +117,9 @@ void Text::move(View *view)
     char string[256];
     string[0] = ' ';
 
-    int i = 0;
+    size_t i = 0;
 
-    for(i = 0; i <= strlen(s); i++)
+    for( ; i <= strlen(s); i++)
       string[i + 1] = s[i];
 
     string[i++] = ' ';
@@ -144,7 +144,6 @@ void Text::move(View *view)
     temp->clear(makeRgb(255, 255, 255));
     //Fl_RGB_Image *image = new Fl_RGB_Image((unsigned char *)temp->data,
     //                                       temp->w, temp->h, 4, 0);
-
     fl_begin_offscreen(offscreen);
     fl_color(FL_WHITE);
     fl_rectf(0, 0, tw, th);
@@ -181,7 +180,7 @@ void Text::move(View *view)
   redraw(view);
 }
 
-void Text::done(View *view)
+void Text::done(View*)
 {
   if(temp)
   {

--- a/Tool.H
+++ b/Tool.H
@@ -63,6 +63,9 @@ public:
 
   // reset tool
   virtual void reset() = 0;
+
+  // virtual dtor
+  virtual ~Tool(){}
 };
 
 #endif

--- a/Undo.cxx
+++ b/Undo.cxx
@@ -99,8 +99,6 @@ void Undo::push()
 
 void Undo::push(int x, int y, int w, int h)
 {
-  int i;
-
   int x1 = x;
   int y1 = y;
   int x2 = x + w - 1;

--- a/View.cxx
+++ b/View.cxx
@@ -347,7 +347,7 @@ int View::handle(int event)
         // convert to utf-8 (e.g. %20 becomes space)
         File::decodeURI(fn);
 
-        for(int i = 0; i < strlen(fn); i++)
+        for(size_t i = 0, n = strlen(fn); i < n; i++)
         {
           if(fn[i] == '\r')
             fn[i] = '\0';


### PR DESCRIPTION
edits `Makefile.am` to add `$(AM_CXXFLAGS)` to `rendera_CXXFLAGS`

edits the following to quash the new errors coming from `-Werror`:
- `Blend.H`
- `File.cxx`
- `Gui.cxx`
- `Paint.H`
- `Palette.cxx`
- `Project.H`
- `Text.cxx`
- `Tool.H`
- `Undo.cxx`
- `View.cxx`
