### PR TITLE
fixes automake warnings for non-POSIX variable names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,8 +83,8 @@ rendera_SOURCES =     \
   Widget.cxx
 
 
-rendera_LDFLAGS = $(shell fltk-config --ldflags)
-rendera_CXXFLAGS = $(shell fltk-config --cxxflags) $(AM_CXXFLAGS)
+rendera_CXXFLAGS = $(FLTK_CONFIG_CXXFLAGS) $(AM_CXXFLAGS)
+rendera_LDFLAGS = $(FLTK_CONFIG_LDFLAGS)
 
 
 nodist_rendera_SOURCES = paths.h

--- a/configure.ac
+++ b/configure.ac
@@ -82,5 +82,11 @@ AC_CHECK_DECLS([M_PI],
   [[#include <math.h>]])
 
 
+FLTK_CONFIG_CXXFLAGS=$(fltk-config --cxxflags)
+FLTK_CONFIG_LDFLAGS=$(fltk-config --ldflags)
+AC_SUBST([FLTK_CONFIG_CXXFLAGS])
+AC_SUBST([FLTK_CONFIG_LDFLAGS])
+
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
edits `configure.ac`: adds variables for `fltk-config --cxxflags`, `fltk-config --ldflags`
edits `Makefile.am`: replaces non-portable shell invocations with autoconf variables
